### PR TITLE
feat: allow specifying a union-type for fixed inputs

### DIFF
--- a/src/scoped_setting.jl
+++ b/src/scoped_setting.jl
@@ -59,7 +59,9 @@ function ScopedSetting{T,F}(f_default::F) where {T,F<:Base.Callable}
     )
 end
 
-ScopedSetting(x_default::T) where T = ScopedSetting{T,Returns{T}}(Returns(x_default))
+ScopedSetting{T1}(x_default::T2) where {T1,T2} = ScopedSetting{T1,Returns{T2}}(Returns(x_default))
+
+ScopedSetting(x_default::T) where T = ScopedSetting{T}(x_default)
 
 function ScopedSetting(f_default::F) where {F<:Function}
     T = Core.Compiler.return_type(f_default, Tuple{})

--- a/test/test_scoped_setting.jl
+++ b/test/test_scoped_setting.jl
@@ -68,4 +68,20 @@ using ScopedValues: @with, with
             () -> @with s_a._scopedval => 21 s_b._scopedval => :violet (s_a[], s_b[])
         )()) == (21, :violet)
     end
+
+    s_union = ScopedSetting{Union{Int,Float64}}(42)
+
+    @testset "union types" begin
+        @test s_union[] == 42
+
+        @with s_union => 11 begin
+            @test s_union[] == 11
+            @test s_union[] isa Int
+        end
+
+        @with s_union => 5.0 begin
+            @test s_union[] == 5.0
+            @test s_union[] isa Float64
+        end
+    end
 end


### PR DESCRIPTION
Having the possibility to specify a union type enables handling cases like https://github.com/EnzymeAD/Reactant.jl/blob/71b744ee0ff3702ed5d4ca9066b8089d274ef30e/src/mlir/IR/Pass.jl#L68 easier